### PR TITLE
Refactor datalog engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.39
+          version: v1.46

--- a/datalog/datalog.go
+++ b/datalog/datalog.go
@@ -529,20 +529,8 @@ func combine(variables MatchedVariables, predicates []Predicate, expressions []E
 					} else {
 						// did not match, we either increase the current index or the previous one
 						// then we check again for a match
-						for i := current; i >= 0; i-- {
-							if indexes[i] < len(*facts)-1 {
-								indexes[i] += 1
-								break
-							} else {
-								if i > 0 {
-									indexes[i] = 0
-									current -= 1
-								} else {
-									// we reached the first predicate, we cannot generate more
-									// combinations, so we stop the task
-									return
-								}
-							}
+						if !advanceIndexes(&current, &indexes, facts) {
+							return
 						}
 					}
 				}
@@ -616,23 +604,30 @@ func combine(variables MatchedVariables, predicates []Predicate, expressions []E
 			}
 
 			// next index
-			for i := current; i >= 0; i-- {
-				if indexes[i] < len(*facts)-1 {
-					indexes[i] += 1
-					break
-				} else {
-					if i > 0 {
-						indexes[i] = 0
-						current -= 1
-					} else {
-						// we reached the first predicate, we cannot generate more
-						// combinations, so we stop the task
-						return
-					}
-				}
+			if !advanceIndexes(&current, &indexes, facts) {
+				return
 			}
 		}
 
 	}(c)
 	return c
+}
+
+func advanceIndexes(current *int, indexes *[]int, facts *FactSet) bool {
+	for i := *current; i >= 0; i-- {
+		if (*indexes)[i] < len(*facts)-1 {
+			(*indexes)[i] += 1
+			break
+		} else {
+			if i > 0 {
+				(*indexes)[i] = 0
+				*current -= 1
+			} else {
+				// we reached the first predicate, we cannot generate more
+				// combinations, so we stop the task
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/datalog/symbol.go
+++ b/datalog/symbol.go
@@ -1,0 +1,255 @@
+package datalog
+
+import (
+	"fmt"
+	"strings"
+)
+
+var DEFAULT_SYMBOLS = [...]string{
+	"read",
+	"write",
+	"resource",
+	"operation",
+	"right",
+	"time",
+	"role",
+	"owner",
+	"tenant",
+	"namespace",
+	"user",
+	"team",
+	"service",
+	"admin",
+	"email",
+	"group",
+	"member",
+	"ip_address",
+	"client",
+	"client_ip",
+	"domain",
+	"path",
+	"version",
+	"cluster",
+	"node",
+	"hostname",
+	"nonce",
+	"query",
+}
+
+var OFFSET = 1024
+
+type SymbolTable []string
+
+func (t *SymbolTable) Insert(s string) String {
+	for i, v := range DEFAULT_SYMBOLS {
+		if string(v) == s {
+			return String(i)
+		}
+	}
+
+	for i, v := range *t {
+		if string(v) == s {
+			return String(OFFSET + i)
+		}
+	}
+	*t = append(*t, s)
+
+	return String(OFFSET + len(*t) - 1)
+}
+
+func (t *SymbolTable) Sym(s string) Term {
+	for i, v := range DEFAULT_SYMBOLS {
+		if string(v) == s {
+			return String(i)
+		}
+	}
+
+	for i, v := range *t {
+		if string(v) == s {
+			return String(OFFSET + i)
+		}
+	}
+	return nil
+}
+
+func (t *SymbolTable) Index(s string) uint64 {
+	for i, v := range DEFAULT_SYMBOLS {
+		if string(v) == s {
+			return uint64(i)
+		}
+	}
+
+	for i, v := range *t {
+		if string(v) == s {
+			return uint64(OFFSET + i)
+		}
+	}
+	panic("index not found")
+}
+
+func (t *SymbolTable) Str(sym String) string {
+	if int(sym) < 1024 {
+		if int(sym) > len(DEFAULT_SYMBOLS)-1 {
+			return fmt.Sprintf("<invalid symbol %d>", sym)
+		} else {
+			return DEFAULT_SYMBOLS[int(sym)]
+		}
+	}
+	if int(sym)-1024 > len(*t)-1 {
+		return fmt.Sprintf("<invalid symbol %d>", sym)
+	}
+	return (*t)[int(sym)-1024]
+}
+
+func (t *SymbolTable) Var(v Variable) string {
+	if int(v) < 1024 {
+		if int(v) > len(DEFAULT_SYMBOLS)-1 {
+			return fmt.Sprintf("<invalid variable %d>", v)
+		} else {
+			return DEFAULT_SYMBOLS[int(v)]
+		}
+	}
+	if int(v)-1024 > len(*t)-1 {
+		return fmt.Sprintf("<invalid variable %d>", v)
+	}
+	return (*t)[int(v)-1024]
+}
+
+func (t *SymbolTable) Clone() *SymbolTable {
+	newTable := *t
+	return &newTable
+}
+
+// SplitOff returns a newly allocated slice containing the elements in the range
+// [at, len). After the call, the receiver will be left containing
+// the elements [0, at) with its previous capacity unchanged.
+func (t *SymbolTable) SplitOff(at int) *SymbolTable {
+	if at > len(*t) {
+		panic("split index out of bound")
+	}
+
+	new := make(SymbolTable, len(*t)-at)
+	copy(new, (*t)[at:])
+
+	*t = (*t)[:at]
+
+	return &new
+}
+
+func (t *SymbolTable) Len() int {
+	return len(*t)
+}
+
+// IsDisjoint returns true if receiver has no elements in common with other.
+// This is equivalent to checking for an empty intersection.
+func (t *SymbolTable) IsDisjoint(other *SymbolTable) bool {
+	m := make(map[string]struct{}, len(*t))
+	for _, s := range *t {
+		m[s] = struct{}{}
+	}
+
+	for _, os := range *other {
+		if _, ok := m[os]; ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Extend insert symbols from the given SymbolTable in the receiving one
+// excluding any Symbols already existing
+func (t *SymbolTable) Extend(other *SymbolTable) {
+	for _, s := range *other {
+		t.Insert(s)
+	}
+}
+
+type SymbolDebugger struct {
+	*SymbolTable
+}
+
+func (d SymbolDebugger) Predicate(p Predicate) string {
+	strs := make([]string, len(p.Terms))
+	for i, id := range p.Terms {
+		var s string
+		if sym, ok := id.(String); ok {
+			s = "\"" + d.Str(sym) + "\""
+		} else if variable, ok := id.(Variable); ok {
+			s = "$" + d.Var(variable)
+		} else {
+			s = fmt.Sprintf("%v", id)
+		}
+		strs[i] = s
+	}
+	return fmt.Sprintf("%s(%s)", d.Str(p.Name), strings.Join(strs, ", "))
+}
+
+func (d SymbolDebugger) Rule(r Rule) string {
+	head := d.Predicate(r.Head)
+	preds := make([]string, len(r.Body))
+	for i, p := range r.Body {
+		preds[i] = d.Predicate(p)
+	}
+	expressions := make([]string, len(r.Expressions))
+	for i, e := range r.Expressions {
+		expressions[i] = d.Expression(e)
+	}
+
+	var expressionsStart string
+	if len(preds) > 0 && len(expressions) > 0 {
+		expressionsStart = ", "
+	}
+
+	return fmt.Sprintf("%s <- %s%s%s", head, strings.Join(preds, ", "), expressionsStart, strings.Join(expressions, ", "))
+}
+
+func (d SymbolDebugger) CheckQuery(r Rule) string {
+	preds := make([]string, len(r.Body))
+	for i, p := range r.Body {
+		preds[i] = d.Predicate(p)
+	}
+	expressions := make([]string, len(r.Expressions))
+	for i, e := range r.Expressions {
+		expressions[i] = d.Expression(e)
+	}
+
+	var expressionsStart string
+	if len(preds) > 0 && len(expressions) > 0 {
+		expressionsStart = ", "
+	}
+
+	return fmt.Sprintf("%s%s%s", strings.Join(preds, ", "), expressionsStart, strings.Join(expressions, ", "))
+}
+
+func (d SymbolDebugger) Expression(e Expression) string {
+	return e.Print(d.SymbolTable)
+}
+
+func (d SymbolDebugger) Check(c Check) string {
+	queries := make([]string, len(c.Queries))
+	for i, q := range c.Queries {
+		queries[i] = d.CheckQuery(q)
+	}
+	return fmt.Sprintf("check if %s", strings.Join(queries, " or "))
+}
+
+func (d SymbolDebugger) World(w *World) string {
+	facts := make([]string, len(*w.facts))
+	for i, f := range *w.facts {
+		facts[i] = d.Predicate(f.Predicate)
+	}
+	rules := make([]string, len(w.rules))
+	for i, r := range w.rules {
+		rules[i] = d.Rule(r)
+	}
+	return fmt.Sprintf("World {{\n\tfacts: %v\n\trules: %v\n}}", facts, rules)
+}
+
+func (d SymbolDebugger) FactSet(s *FactSet) string {
+	strs := make([]string, len(*s))
+	for i, f := range *s {
+		strs[i] = d.Predicate(f.Predicate)
+	}
+	return fmt.Sprintf("%v", strs)
+}

--- a/samples/samples_test.go
+++ b/samples/samples_test.go
@@ -653,16 +653,12 @@ func TestSample22_DefaultSymbols(t *testing.T) {
 			v, err := b.Authorizer(loadRootPublicKey(t, v))
 			require.NoError(t, err)
 
-			check1, err := parser.FromStringCheck(`check if read(0), write(1), resource(2), operation(3), right(4), time(5), role(6), owner(7), tenant(8), namespace(9), user(10), team(11), service(12), admin(13), email(14), group(15), member(16)`)
+			check1, err := parser.FromStringCheck(`check if read(0), write(1), resource(2), operation(3),
+			right(4), time(5), role(6), owner(7), tenant(8), namespace(9), user(10), team(11), service(12),
+			admin(13), email(14), group(15), member(16), ip_address(17), client(18), client_ip(19),
+			domain(20), path(21), version(22), cluster(23), node(24), hostname(25), nonce(26), query(27)`)
 			require.NoError(t, err)
 			v.AddCheck(check1)
-
-			// separate in two checks because the parser gest slow at more than 20 facts
-			check2, err := parser.FromStringCheck(`check if
-			ip_address(17), client(18), client_ip(19), domain(20), path(21), version(22),
-			cluster(23), node(24), hostname(25), nonce(26), query(27)`)
-			require.NoError(t, err)
-			v.AddCheck(check2)
 
 			v.AddPolicy(biscuit.DefaultAllowPolicy)
 


### PR DESCRIPTION
rewrite the datalog engine to run in a goroutine and send results over a channel. This allows us to construct facts lazily instead of pregenerating large lists