### PR TITLE
Fix v2 release

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/biscuit-auth/biscuit-go/datalog"
-	"github.com/biscuit-auth/biscuit-go/pb"
+	"github.com/biscuit-auth/biscuit-go/v2/datalog"
+	"github.com/biscuit-auth/biscuit-go/v2/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/biscuit.go
+++ b/biscuit.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/biscuit-auth/biscuit-go/datalog"
-	"github.com/biscuit-auth/biscuit-go/pb"
+	"github.com/biscuit-auth/biscuit-go/v2/datalog"
+	"github.com/biscuit-auth/biscuit-go/v2/pb"
 
 	//"github.com/biscuit-auth/biscuit-go/sig"
 	"google.golang.org/protobuf/proto"

--- a/biscuit_test.go
+++ b/biscuit_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/biscuit-auth/biscuit-go/datalog"
+	"github.com/biscuit-auth/biscuit-go/v2/datalog"
 	"github.com/stretchr/testify/require"
 )
 

--- a/builder.go
+++ b/builder.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/biscuit-auth/biscuit-go/datalog"
-	"github.com/biscuit-auth/biscuit-go/pb"
+	"github.com/biscuit-auth/biscuit-go/v2/datalog"
+	"github.com/biscuit-auth/biscuit-go/v2/pb"
 
 	//"github.com/biscuit-auth/biscuit-go/sig"
 	"google.golang.org/protobuf/proto"

--- a/converters.go
+++ b/converters.go
@@ -3,8 +3,8 @@ package biscuit
 import (
 	"fmt"
 
-	"github.com/biscuit-auth/biscuit-go/datalog"
-	"github.com/biscuit-auth/biscuit-go/pb"
+	"github.com/biscuit-auth/biscuit-go/v2/datalog"
+	"github.com/biscuit-auth/biscuit-go/v2/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/converters_v2.go
+++ b/converters_v2.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/biscuit-auth/biscuit-go/datalog"
-	"github.com/biscuit-auth/biscuit-go/pb"
+	"github.com/biscuit-auth/biscuit-go/v2/datalog"
+	"github.com/biscuit-auth/biscuit-go/v2/pb"
 )
 
 func tokenFactToProtoFactV2(input datalog.Fact) (*pb.FactV2, error) {

--- a/converters_v2_test.go
+++ b/converters_v2_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/biscuit-auth/biscuit-go/datalog"
-	"github.com/biscuit-auth/biscuit-go/pb"
+	"github.com/biscuit-auth/biscuit-go/v2/datalog"
+	"github.com/biscuit-auth/biscuit-go/v2/pb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )

--- a/example_test.go
+++ b/example_test.go
@@ -5,8 +5,8 @@ import (
 	"crypto/rand"
 	"fmt"
 
-	"github.com/biscuit-auth/biscuit-go"
-	"github.com/biscuit-auth/biscuit-go/parser"
+	"github.com/biscuit-auth/biscuit-go/v2"
+	"github.com/biscuit-auth/biscuit-go/v2/parser"
 )
 
 func ExampleBiscuit() {

--- a/experiments/pop_test.go
+++ b/experiments/pop_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/biscuit-auth/biscuit-go"
+	"github.com/biscuit-auth/biscuit-go/v2"
 	"github.com/biscuit-auth/biscuit-go/sig"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/biscuit-auth/biscuit-go
+module github.com/biscuit-auth/biscuit-go/v2
 
 go 1.17
 

--- a/parser/grammar.go
+++ b/parser/grammar.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
-	"github.com/biscuit-auth/biscuit-go"
+	"github.com/biscuit-auth/biscuit-go/v2"
 )
 
 type Comment string

--- a/parser/grammar_test.go
+++ b/parser/grammar_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/participle/v2"
-	"github.com/biscuit-auth/biscuit-go"
+	"github.com/biscuit-auth/biscuit-go/v2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
-	"github.com/biscuit-auth/biscuit-go"
+	"github.com/biscuit-auth/biscuit-go/v2"
 )
 
 var (

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/biscuit-auth/biscuit-go"
+	"github.com/biscuit-auth/biscuit-go/v2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/samples/samples_test.go
+++ b/samples/samples_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/biscuit-auth/biscuit-go"
-	"github.com/biscuit-auth/biscuit-go/parser"
+	"github.com/biscuit-auth/biscuit-go/v2"
+	"github.com/biscuit-auth/biscuit-go/v2/parser"
 	"github.com/stretchr/testify/require"
 )
 

--- a/types.go
+++ b/types.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/biscuit-auth/biscuit-go/datalog"
+	"github.com/biscuit-auth/biscuit-go/v2/datalog"
 )
 
 const MinSchemaVersion uint32 = 3

--- a/types_test.go
+++ b/types_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/biscuit-auth/biscuit-go/datalog"
+	"github.com/biscuit-auth/biscuit-go/v2/datalog"
 	"github.com/stretchr/testify/require"
 )
 

--- a/website_test.go
+++ b/website_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/biscuit-auth/biscuit-go"
-	"github.com/biscuit-auth/biscuit-go/parser"
+	"github.com/biscuit-auth/biscuit-go/v2"
+	"github.com/biscuit-auth/biscuit-go/v2/parser"
 )
 
 // code examples for the documentation at https://www.biscuitsec.org


### PR DESCRIPTION
As outlined in #104, it's currently impossible to import v2 of this package.
This PR fixes the issue with the "release version in go.mod URL" strategy.

I've tested this at https://github.com/guregu/biscuit-go and it looks like it works well.