### PR TITLE
allow customizing base world & syms for authorizer

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -48,15 +48,9 @@ var _ Authorizer = (*authorizer)(nil)
 
 type AuthorizerOption func(w *authorizer)
 
-func WithBaseWorld(baseWorld *datalog.World) AuthorizerOption {
+func WithWorldOptions(opts ...datalog.WorldOption) AuthorizerOption {
 	return func(a *authorizer) {
-		a.baseWorld = baseWorld
-	}
-}
-
-func WithBaseSymbolTable(syms *datalog.SymbolTable) AuthorizerOption {
-	return func(a *authorizer) {
-		a.baseSymbols = syms.Clone()
+		a.baseWorld = datalog.NewWorld(opts...)
 	}
 }
 

--- a/biscuit.go
+++ b/biscuit.go
@@ -271,7 +271,7 @@ func (b *Biscuit) Seal(rng io.Reader) (*Biscuit, error) {
 // Checks the signature and creates an Authorizer
 // The Authorizer can then test the authorizaion policies and
 // accept or refuse the request
-func (b *Biscuit) Authorizer(root ed25519.PublicKey) (Authorizer, error) {
+func (b *Biscuit) Authorizer(root ed25519.PublicKey, opts ...AuthorizerOption) (Authorizer, error) {
 	currentKey := root
 
 	// for now we only support Ed25519
@@ -351,7 +351,7 @@ func (b *Biscuit) Authorizer(root ed25519.PublicKey) (Authorizer, error) {
 		return nil, errors.New("biscuit: cannot find proof")
 	}
 
-	return NewVerifier(b)
+	return NewVerifier(b, opts...)
 }
 
 func (b *Biscuit) Checks() [][]datalog.Check {


### PR DESCRIPTION
I've run into some cases where the default world max duration wasn't quite enough, resulting in intermittent failures. This PR exposes options to the caller to override the default limits (and for completeness, the default symbol table).

e.g.
```go
b, err := biscuit.Unmarshal(token)
// ...

authorizer, err := b.Authorizer(
    publicRoot,
    biscuit.WithBaseWorld(
        datalog.NewWorld(
            datalog.WithMaxDuration(3 * time.Millisecond),
        ),
    ),
)
// ...
```