### PR TITLE
Parameters

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -504,7 +504,7 @@ func TestParserFact(t *testing.T) {
 	p := New()
 	for _, testCase := range getFactTestCases() {
 		t.Run(testCase.Input, func(t *testing.T) {
-			fact, err := p.Fact(testCase.Input)
+			fact, err := p.Fact(testCase.Input, nil)
 			if testCase.ExpectFailure {
 				if testCase.ExpectErr != nil {
 					require.Equal(t, testCase.ExpectErr, err)
@@ -523,7 +523,7 @@ func TestParseRule(t *testing.T) {
 	p := New()
 	for _, testCase := range getRuleTestCases() {
 		t.Run(testCase.Input, func(t *testing.T) {
-			rule, err := p.Rule(testCase.Input)
+			rule, err := p.Rule(testCase.Input, nil)
 			if testCase.ExpectFailure {
 				if testCase.ExpectErr != nil {
 					require.Equal(t, testCase.ExpectErr, err)
@@ -542,7 +542,7 @@ func TestParserCheck(t *testing.T) {
 	p := New()
 	for _, testCase := range getCheckTestCases() {
 		t.Run(testCase.Input, func(t *testing.T) {
-			caveat, err := p.Check(testCase.Input)
+			caveat, err := p.Check(testCase.Input, nil)
 			if testCase.ExpectFailure {
 				if testCase.ExpectErr != nil {
 					require.Equal(t, testCase.ExpectErr, err)
@@ -568,7 +568,7 @@ func TestMustParserFact(t *testing.T) {
 				}()
 			}
 
-			fact := p.Must().Fact(testCase.Input)
+			fact := p.Must().Fact(testCase.Input, nil)
 			require.Equal(t, testCase.Expected, fact)
 		})
 	}

--- a/samples/samples_test.go
+++ b/samples/samples_test.go
@@ -179,7 +179,7 @@ func CompareBlocks(token biscuit.Biscuit, blocks []Block, t *testing.T) {
 
 	rng := rand.Reader
 	_, privateRoot, _ := ed25519.GenerateKey(rng)
-	authority, err := p.Block(blocks[0].Code)
+	authority, err := p.Block(blocks[0].Code, nil)
 	require.NoError(t, err)
 	builder := biscuit.NewBuilder(privateRoot)
 	builder.AddBlock(authority)
@@ -188,7 +188,7 @@ func CompareBlocks(token biscuit.Biscuit, blocks []Block, t *testing.T) {
 	rebuilt := *r
 
 	for _, b := range blocks[1:] {
-		parsed, err := p.Block(b.Code)
+		parsed, err := p.Block(b.Code, nil)
 		require.NoError(t, err)
 		builder := rebuilt.CreateBlock()
 		builder.AddBlock(parsed)
@@ -202,7 +202,7 @@ func CompareBlocks(token biscuit.Biscuit, blocks []Block, t *testing.T) {
 
 func CompareResult(root_key ed25519.PublicKey, filename string, token biscuit.Biscuit, v Validation, t *testing.T) {
 	p := parser.New()
-	authorizer_code, err := p.Authorizer(v.AuthorizerCode)
+	authorizer_code, err := p.Authorizer(v.AuthorizerCode, nil)
 	require.NoError(t, err)
 	authorizer, err := token.Authorizer(root_key)
 


### PR DESCRIPTION
Parsed datalog snippets can now contain placeholders (for instance: `check if right({resource}, {operation}`). This allows embedding dynamic values in datalog, without the risk of injections.

All the `FromString*` methods now have a `FromString*WithParams` counterpart that take an extra
`map[string]Term` value.

/!\ For now, it is the caller's responsibility to make sure the all the placeholders **in expressions** have a corresponding value defined (same as making sure sets don't contain variables).
Placeholders set in predicates don't have this issue. This is an underlying issue of the parser; it was not introduced by this change.
