### PR TITLE
Added sign func for external signing method

### DIFF
--- a/biscuit_test.go
+++ b/biscuit_test.go
@@ -402,7 +402,7 @@ func TestNewErrors(t *testing.T) {
 
 	t.Run("authority block Strings overlap", func(t *testing.T) {
 		_, privateRoot, _ := ed25519.GenerateKey(rng)
-		_, err := New(rng, privateRoot, &datalog.SymbolTable{"String1", "String2"}, &Block{
+		_, err := New(rng, DefaultSignMethod(privateRoot), &datalog.SymbolTable{"String1", "String2"}, &Block{
 			symbols: &datalog.SymbolTable{"String1"},
 		})
 		require.Equal(t, ErrSymbolTableOverlap, err)


### PR DESCRIPTION
- Added default signing method for local key
- Added `WithCustomSignMethod` builder option
- Fixed tests


Interface for external signers, like [transit engine](https://developer.hashicorp.com/vault/docs/secrets/transit#ed25519) in `vault`. By this method i can sign tokens without generating or loading private keys in memory