### PR TITLE
Allow associating an ID with a biscuit's root key

### DIFF
--- a/biscuit.go
+++ b/biscuit.go
@@ -455,11 +455,8 @@ func (b *Biscuit) BlockCount() int {
 	return len(b.container.Blocks)
 }
 
-func (b *Biscuit) RootKeyID() (uint32, bool) {
-	if v := b.container.RootKeyId; v != nil {
-		return *v, true
-	}
-	return 0, false
+func (b *Biscuit) RootKeyID() *uint32 {
+	return b.container.RootKeyId
 }
 
 func (b *Biscuit) String() string {

--- a/biscuit_test.go
+++ b/biscuit_test.go
@@ -33,9 +33,9 @@ func TestBiscuit(t *testing.T) {
 	b1, err := builder.Build()
 	require.NoError(t, err)
 	{
-		keyID, ok := b1.RootKeyID()
-		require.True(t, ok, "root key ID present")
-		require.EqualValues(t, rootKeyID, keyID, "root key ID")
+		keyID := b1.RootKeyID()
+		require.NotNil(t, keyID, "root key ID present")
+		require.EqualValues(t, rootKeyID, *keyID, "root key ID")
 	}
 
 	b1ser, err := b1.Serialize()
@@ -45,9 +45,9 @@ func TestBiscuit(t *testing.T) {
 	b1deser, err := Unmarshal(b1ser)
 	require.NoError(t, err)
 	{
-		keyID, ok := b1deser.RootKeyID()
-		require.True(t, ok, "root key ID present after round trip")
-		require.EqualValues(t, rootKeyID, keyID, "root key ID after round trip")
+		keyID := b1deser.RootKeyID()
+		require.NotNil(t, keyID, "root key ID present after round trip")
+		require.EqualValues(t, rootKeyID, *keyID, "root key ID after round trip")
 	}
 
 	block2 := b1deser.CreateBlock()

--- a/options.go
+++ b/options.go
@@ -1,0 +1,51 @@
+package biscuit
+
+import "io"
+
+type compositionOption interface {
+	builderOption
+	biscuitOption
+}
+
+type rngOption struct {
+	io.Reader
+}
+
+func (o rngOption) applyToBuilder(b *builderOptions) {
+	if r := o.Reader; r != nil {
+		b.rng = o
+	}
+}
+
+func (o rngOption) applyToBiscuit(b *biscuitOptions) error {
+	if r := o.Reader; r != nil {
+		b.rng = r
+	}
+	return nil
+}
+
+// WithRNG supplies a random number generator as a byte stream from which to read when generating
+// key pairs with which to sign blocks within biscuits.
+func WithRNG(r io.Reader) compositionOption {
+	return rngOption{r}
+}
+
+type rootKeyIDOption uint32
+
+func (o rootKeyIDOption) applyToBuilder(b *builderOptions) {
+	id := uint32(o)
+	b.rootKeyID = &id
+}
+
+func (o rootKeyIDOption) applyToBiscuit(b *biscuitOptions) error {
+	id := uint32(o)
+	b.rootKeyID = &id
+	return nil
+}
+
+// WithRootKeyID specifies the identifier for the root key pair used to sign a biscuit's authority
+// block, allowing a consuming party to later select the corresponding public key to validate that
+// signature.
+func WithRootKeyID(id uint32) compositionOption {
+	return rootKeyIDOption(id)
+}


### PR DESCRIPTION
In order to accommodate biscuit issuers with multiple key pairs in use, whether concurrently or in an ongoing rotation cycle, biscuits can record and expose an identifier for the root private key used to sign its authority block. Allow issuers to associate such an identifier with the private key when creating a new biscuit.

Introduce the option function `WithRootKeyID` to supply such an identifier at composition time, and the `(*Biscuit).RootKeyID` method to query this identifier later.

Contributes to #150.